### PR TITLE
Add golang

### DIFF
--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -26,9 +26,12 @@ jobs:
           echo "Old: $old"
           echo "New: $new"
           #status=$(go run cmd/sdt/main.go semantic -A ${rev}:)
-          status=$(go run cmd/sdt/main.go semantic)
+          status=$(go run cmd/sdt/main.go semantic --minimal 2>&1)
           echo "$status" | tee $GITHUB_OUTPUT
-          git diff $old $new
+          # Debugging. TODO: remove
+          echo "git diff $old $new"
+          echo "FAILS: fatal: bad object ..."
+          echo "Error: Process completed with exit code 128."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -26,7 +26,7 @@ jobs:
           echo "Old: $old"
           echo "New: $new"
           #status=$(go run cmd/sdt/main.go semantic -A ${rev}:)
-          status=$(go run cmd/sdt/main.go semantic --minimal 2>&1)
+          status=$(go run cmd/sdt/main.go semantic)
           echo "$status" | tee $GITHUB_OUTPUT
           # Debugging. TODO: remove
           echo "git diff $old $new"

--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -35,7 +35,9 @@ jobs:
           old=$(git log | grep 'Merge.*into.*' | head -1 | sed 's/^.* into //')
           status=$(go run cmd/sdt/main.go semantic -A "${old}:" -B "${new}:" -m -d)
           echo "Comparing revision $old to $new" >> SDT.analysis
+          echo "<pre>" >> SDT.analysis
           echo "$status" >> SDT.analysis
+          echo "</pre>" >> SDT.analysis
           echo "$status" # Workflow sees the report also
           
         env:

--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -18,6 +18,16 @@ jobs:
         with:
           go-version: 1.19
 
+      - name: Build jsonformat tool
+        run: |
+          go build -o "$GITHUB_WORKSPACE/jsonformat" cmd/jsonformat/main.go &&
+          echo "$GITHUB_WORKSPACE/" >> $GITHUB_PATH
+
+      - name: Build gotree tool
+        run: |
+          go build -o "$GITHUB_WORKSPACE/gotree" cmd/gotree/main.go &&
+          echo "$GITHUB_WORKSPACE/" >> $GITHUB_PATH
+
       - name: Analyze semantic changes
         id: pr
         run: |

--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -21,12 +21,14 @@ jobs:
         run: |
           echo "GH Action sees only a partial revision tree"
           git log
-          git diff
-          rev=$(git log -n1 | grep Merge | sed 's/ into .*$//;s/^ *Merge //')
-          echo $rev
+          old=$(git log -n1 | grep Merge | sed 's/ into .*$//;s/^ *Merge //')
+          new=$(git log -n1 | grep Merge | sed 's/^.* into //')
+          echo "Old: $old"
+          echo "New: $new"
           #status=$(go run cmd/sdt/main.go semantic -A ${rev}:)
           status=$(go run cmd/sdt/main.go semantic)
           echo "$status" | tee $GITHUB_OUTPUT
+          git diff $old $new
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -31,13 +31,11 @@ jobs:
       - name: Analyze semantic changes
         id: pr
         run: |
-          old=$(git log | grep 'Merge.*into.*' | head -1 | sed 's/ into .*$//;s/^ *Merge //')
-          new=$(git log | grep 'Merge.*into.*' | head -1 | sed 's/^.* into //')
+          new=$(git log | grep 'Merge.*into.*' | head -1 | sed 's/ into .*$//;s/^ *Merge //')
+          old=$(git log | grep 'Merge.*into.*' | head -1 | sed 's/^.* into //')
           status=$(go run cmd/sdt/main.go semantic -A "${old}:" -B "${new}:" -m -d)
-          echo "```" >> SDT.analysis # Markdown for comment
           echo "Comparing revision $old to $new" >> SDT.analysis
           echo "$status" >> SDT.analysis
-          echo "```" >> SDT.analysis
           echo "$status" # Workflow sees the report also
           
         env:

--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -10,6 +10,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -19,27 +21,21 @@ jobs:
       - name: Analyze semantic changes
         id: pr
         run: |
-          echo "GH Action sees only a partial revision tree"
-          git log
-          old=$(git log -n1 | grep Merge | sed 's/ into .*$//;s/^ *Merge //')
-          new=$(git log -n1 | grep Merge | sed 's/^.* into //')
-          echo "Old: $old"
-          echo "New: $new"
-          #status=$(go run cmd/sdt/main.go semantic -A ${rev}:)
-          status=$(go run cmd/sdt/main.go semantic)
-          echo "$status" | tee $GITHUB_OUTPUT
-          # Debugging. TODO: remove
-          echo "git diff $old $new"
-          echo "FAILS: fatal: bad object ..."
-          echo "Error: Process completed with exit code 128."
+          old=$(git log | grep 'Merge.*into.*' | head -1 | sed 's/ into .*$//;s/^ *Merge //')
+          new=$(git log | grep 'Merge.*into.*' | head -1 | sed 's/^.* into //')
+          status=$(go run cmd/sdt/main.go semantic -A "${old}:" -B "${new}:" -m -d)
+          echo "```" >> SDT.analysis # Markdown for comment
+          echo "Comparing revision $old to $new" >> SDT.analysis
+          echo "$status" >> SDT.analysis
+          echo "```" >> SDT.analysis
+          echo "$status" # Workflow sees the report also
+          
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add a comment to the PR
         uses: mshick/add-pr-comment@v2
         with:
-          message: |
-            **Analysis**
-            ${{ steps.pr.outputs.status }}
+          message-path: SDT.analysis
 
             

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ with:
 
 The extra tool `jsonformat` is not needed for users who prefer to use the
 much more powerful [`jq`](https://stedolan.github.io/jq/) in their
-`.sdt.toml` configuration.
+`.sdt.toml` configuration.  The tool `gotree` produces a somewhat customized
+parse tree, so a different tool is unlikely to be compatible with `sdt`.
 
 The separate step of setting the "executable bit" is probably not needed,
 but does not harm.  If you are installing to a location that only needs

--- a/cmd/gotree/main.go
+++ b/cmd/gotree/main.go
@@ -63,6 +63,9 @@ func main() {
 			`Assign|Arrow|Go|Begin|Select|Opening|Closing|Star|Colon|Ellipsis|` +
 			`.*Pos|[LR]paren|[LR]brace|[LR]brack` +
 			`): )(.*)`)
+	reCloseBrace := regexp.MustCompile(`^ *}$`)
+	reEndLineBrace := regexp.MustCompile(`{$`)
+
 	fmt.Println("SrcLn | Node")
 	lines := strings.Split(buf.String(), "\n")
 	lineno := 0
@@ -71,9 +74,9 @@ func main() {
 		line = strings.Replace(line, ".  ", "  ", -1)
 
 		// The final parts of the tree are not line-by-line of interest
-		if strings.HasPrefix(line, "Scope: ") ||
-			strings.HasPrefix(line, "Imports: ") ||
-			strings.HasPrefix(line, "Unresolved: ") {
+		if strings.HasPrefix(line, "  Scope: ") ||
+			strings.HasPrefix(line, "  Imports: ") ||
+			strings.HasPrefix(line, "  Unresolved: ") {
 			break
 		}
 
@@ -83,9 +86,12 @@ func main() {
 			if len(parts) == 3 {
 				lineno, _ = strconv.Atoi(strings.Replace(parts[1], " ", "0", -1))
 			}
-			justNode := lineMark.ReplaceAllString(line, "$1$2")
-			fmt.Fprintf(os.Stdout, "%05d | %s?\n", lineno, justNode)
+			//justNode := lineMark.ReplaceAllString(line, "$1$2")
+			//fmt.Fprintf(os.Stdout, "%05d | %s?\n", lineno, justNode)
+		} else if reCloseBrace.MatchString(line) {
+			// Skip output of lines with only braces, redundant to indent
 		} else {
+			line = reEndLineBrace.ReplaceAllString(line, "")
 			fmt.Fprintf(os.Stdout, "%05d | %s\n", lineno, line)
 		}
 	}

--- a/cmd/gotree/main.go
+++ b/cmd/gotree/main.go
@@ -1,0 +1,80 @@
+/* The purpose of this small program is to generate an AST for a Golang
+ * package.  It provides no options and always requires exactly one filename
+ * as an argument.  
+ */
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	//"strconv"
+	"strings"
+
+	"github.com/atlantistechnology/sdt/pkg/utils"
+)
+
+func main() {
+	var err error
+	var code []byte
+	raw := os.Getenv("GOTREE_RAW") != "" 
+
+	if len(os.Args) != 2 {
+		utils.Fail("`%s` requires exactly one filename argument", os.Args[0])
+	}
+	if os.Args[1] == "-h" || os.Args[1] == "--help" {
+		utils.Info("Golang parse tree: may set GOTREE_RAW for unmassaged AST")
+		return
+	}
+
+	filename := os.Args[1]
+	code, err = os.ReadFile(filename)
+	if err != nil {
+		utils.Fail("Unable for read file %s", filename)
+	}
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", code, parser.AllErrors)
+	if err != nil {
+		utils.Fail("Unable for parse Golang file %s (%s)", filename, err)
+	}
+
+	if raw {
+		err = ast.Print(fset, f)
+		if err != nil {
+			utils.Fail("Unable for to print parsed Golang file %s (%s)", filename, err)
+		}
+		return
+	}
+
+	var buf bytes.Buffer
+	err = ast.Fprint(&buf, fset, f, nil)
+	if err != nil {
+		utils.Fail("Unable for to print parsed Golang file %s (%s)", filename, err)
+	}
+
+	fmt.Println("SrcLn | Node")
+	lines := strings.Split(buf.String(), "\n")
+	lineno := 0
+	//var n int
+	for _, line := range lines {
+		line = line[utils.Min(8, len(line)):]
+		line = strings.Replace(line, ".  ", "  ", -1)
+		if strings.Contains(line, "Pos: ") {
+			parts := strings.Split(line, ":")
+			if len(parts) == 3 {
+				fmt.Println("XXX", parts)
+			}
+			//if n, err = strconv.Atoi(strings.Split(line, ":")[1]); err != nil {
+			//	lineno = n
+			//}
+		}
+		fmt.Fprintf(os.Stdout, "%05d  | %s\n", lineno, line)
+	}
+
+
+}
+

--- a/cmd/sdt/main.go
+++ b/cmd/sdt/main.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/BurntSushi/toml"
 
 	"github.com/atlantistechnology/sdt/pkg/types"
@@ -166,6 +167,10 @@ func getOptions() types.Options {
 
 	if os.Getenv("CI") == "true" {
 		dumbterm = true
+	}
+
+	if dumbterm {
+		color.NoColor = true
 	}
 
 	// Create a struct with the command-line configured options

--- a/pkg/golang/golang.go
+++ b/pkg/golang/golang.go
@@ -1,0 +1,56 @@
+package golang
+
+import (
+	"regexp"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
+
+	"github.com/atlantistechnology/sdt/pkg/types"
+	"github.com/atlantistechnology/sdt/pkg/utils"
+)
+
+func simplifyParseTree(parseTree string) string {
+	reNoLineCol := regexp.MustCompile(`(?m)^.{5} \| `)
+	return reNoLineCol.ReplaceAllString(parseTree, "")
+}
+
+func Diff(filename string, options types.Options, config types.Config) string {
+	var headTree []byte
+	var currentTree []byte
+
+	goCmd := config.Commands["go"].Executable
+	switches := config.Commands["go"].Switches
+	canonical := false // Generate AST, don't canonicalize
+
+	if filename == "" {
+		//-- Comparison of two local files
+		filename, headTree, currentTree = utils.LocalFileTrees(
+			goCmd, switches, options, "Go", canonical)
+	} else {
+		//-- Comparison of a branch/revision to a current file
+		headTree, currentTree = utils.RevisionToCurrentTree(
+			filename, goCmd, switches, options, "Go", canonical)
+	}
+
+	// Make the trees into slightly simpler string representation
+	headTreeString := simplifyParseTree(string(headTree))
+	currentTreeString := simplifyParseTree(string(currentTree))
+
+	// Perform the diff between the versions
+	dmp := diffmatchpatch.New()
+	diffs := dmp.DiffMain(headTreeString, currentTreeString, false)
+
+	if options.Parsetree {
+		return utils.ColorDiff(dmp, diffs,
+			types.Go, options.Dumbterm, options.Minimal)
+	}
+
+	if options.Semantic {
+		return utils.SemanticChanges(
+			dmp, diffs, filename,
+			headTree, headTreeString,
+			types.Go, options.Dumbterm, options.Minimal)
+	}
+
+	return "| No diff type specified"
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -81,7 +81,7 @@ const (
 	Python
 	JavaScript
 	JSON
-	Golang
+	Go
 	SomeOtherLanguage
 )
 
@@ -124,6 +124,14 @@ var Commands = map[string]Command{
 	// For an example of using external tool `jq`, see `samples/.sdt.toml`
 	"json": {
 		Executable: "jsonformat",
+		Switches:   []string{},
+		Options:    "",
+	},
+	// A small and simple tool within this project called `gotree`.  The tool
+	// modestly customizes the layout of the parse tree, so it is unlikely
+	// that a different tool would produce a format suitable for the analysis
+	"go": {
+		Executable: "gotree",
 		Switches:   []string{},
 		Options:    "",
 	},

--- a/pkg/utils/git/git.go
+++ b/pkg/utils/git/git.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/gobwas/glob"
 
+	"github.com/atlantistechnology/sdt/pkg/golang"
 	"github.com/atlantistechnology/sdt/pkg/javascript"
 	"github.com/atlantistechnology/sdt/pkg/json_canonical"
 	"github.com/atlantistechnology/sdt/pkg/python"
@@ -59,8 +60,7 @@ func CompareFileType(
 	case ".json":
 		diffColor.Println(json_canonical.Diff(filename, options, config))
 	case ".go":
-		// TODO: Need to investigate AST tools
-		diffColor.Println("| Comparison with Golang syntax tree or canonicalization")
+		diffColor.Println(golang.Diff(filename, options, config))
 	default:
 		diffColor.Println("| No available semantic analyzer for this format")
 	}

--- a/pkg/utils/git/git.go
+++ b/pkg/utils/git/git.go
@@ -226,6 +226,7 @@ func ParseGitDiffCompact(diff string, options types.Options, config types.Config
 			Semantic:    options.Semantic,
 			Parsetree:   options.Parsetree,
 			Glob:        options.Glob,
+			Minimal:     options.Minimal,
 			Verbose:     options.Verbose,
 			Dumbterm:    options.Dumbterm,
 			Source:      src,

--- a/pkg/utils/git/git.go
+++ b/pkg/utils/git/git.go
@@ -109,6 +109,8 @@ func ParseGitDiffCompact(diff string, options types.Options, config types.Config
 	delFile := color.New(color.FgRed)
 	moveFile := color.New(color.FgMagenta)
 	changeFile := color.New(color.FgCyan)
+
+
 	var changed, added, gone, moved []string
 
 	if len(lines) <= 1 {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"golang.org/x/exp/constraints"
@@ -135,7 +136,7 @@ func BufferToDiff(buff bytes.Buffer,
 		for _, line := range lines {
 			if strings.Contains(line, add) || strings.Contains(line, del) {
 				changed = append(changed, line)
-			} else if m, _ := regexp.MatchString(`^..3[123]m(@@|-|\+)`, line); m {
+			} else if m, _ := regexp.MatchString(`^..3.m(@@|-|\+)`, line); m {
 				changed = append(changed, line)
 			} else if m, _ := regexp.MatchString("^..33mSegments with likely", line); m {
 				changed = append(changed, line)
@@ -279,6 +280,18 @@ func SemanticChanges(
 						diffPositions.Add(posOfInterest)
 					}
 				}
+			case types.Go:
+				// For specialized parse tree format created by `gotree`,
+				// the line number is always a prefix to the diff line
+				line := string(treeLines[parseTreeLineNum])
+				if line[0:5] == "SrcLn" {
+					continue
+				}
+				lineNo, err := strconv.Atoi(line[0:5])
+				if err != nil {
+					Fail("Cannot find line number in %s parse tree: `%s`", filename, line)
+				}
+				diffLines.Add(uint32(lineNo))
 			}
 		}
 	}
@@ -341,6 +354,9 @@ func ColorDiff(
 		reBlankln := regexp.MustCompile(`(?m)^\s*$[\r\n]*`)
 		transforms = append(transforms,
 			*reStart, *reEnd, *reBraceOnly, *rePunct, *reBlankln)
+	case types.Go:
+		// NOTE: `gotree` already produces simplified parse tree
+
 	}
 
 	buff.WriteString("Comparison of parse trees or canonical format\n")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -121,9 +121,7 @@ func BufferToDiff(buff bytes.Buffer,
 			}
 			ret = strings.Join(changed, "\n")
 		}
-		ret = rePrepend.ReplaceAllString(ret,
-			types.Colors.Header+"| "+types.Colors.Clear)
-		return ret
+		return rePrepend.ReplaceAllString(ret, "| ")
 	}
 
 	ret := buff.String()

--- a/samples/hello0.go
+++ b/samples/hello0.go
@@ -1,0 +1,9 @@
+//go:build exclude
+
+package hello
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello world")
+}

--- a/samples/hello1.go
+++ b/samples/hello1.go
@@ -1,0 +1,11 @@
+//go:build exclude
+
+package hello
+
+import "fmt"
+
+func main() {
+	fmt.Println(
+		"hello world",
+	)
+}

--- a/samples/hello2.go
+++ b/samples/hello2.go
@@ -1,0 +1,9 @@
+//go:build exclude
+
+package goodbye
+
+import "fmt"
+
+func main() {
+	fmt.Println("goodbye world")
+}


### PR DESCRIPTION
Ready to merge.  Includes support for Golang itself, and the formatting of the comment created in a GH action is now clean and attractive.

The comment produced led me to figuring out why the --minimal option was not passed along correctly. The current comment shows *only* the actual changed lines (that are also semantically relevant), not surrounding context, to minimize size of comment.

I'm not sure if this analysis skips any diff segments, since this is generally new functionality where we *expect* the semantics to change; but it might, and it can in general.